### PR TITLE
upgrade num-xxx dependencies to allow wasm-unknown-unknown target compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ version = "0.6.3"
 
 [dependencies]
 lazy_static = "1.0.*"
-num-bigint = "0.1.*"
-num-rational = "0.1.*"
-num-traits = "0.1.*"
+num-bigint = "0.2.*"
+num-rational = "0.2.*"
+num-traits = "0.2.*"


### PR DESCRIPTION
Version 0.1.* of num-xxx depends on deprecated rustc-serialize which is not compatible with wasm-unknown-unknown target.